### PR TITLE
Dynamic auth

### DIFF
--- a/k8y.gemspec
+++ b/k8y.gemspec
@@ -30,6 +30,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency("faraday", "~> 1.6")
   spec.add_dependency("railties", "~> 6.0")
   spec.add_dependency("recursive-open-struct", "~>1.1")
+  spec.add_dependency("googleauth")
 
   spec.add_development_dependency("byebug", "~> 11")
   spec.add_development_dependency("minitest", "~> 5")

--- a/lib/k8y/rest/auth.rb
+++ b/lib/k8y/rest/auth.rb
@@ -5,13 +5,16 @@ require_relative "auth/factory"
 module K8y
   module REST
     module Auth
-      extend self
-      InvalidAuthTypeError = Class.new(Error)
+      class << self
+        def from_kubeconfig(kubeconfig, context: nil)
+          context = context ? context : kubeconfig.current_context
+          auth_info = kubeconfig.user_for_context(context).auth_info
+          from_auth_info(auth_info)
+        end
 
-      def from_kubeconfig(kubeconfig, context: nil)
-        context = context ? context : kubeconfig.current_context
-        auth_info = kubeconfig.user_for_context(context).auth_info
-        Factory.new_from_kubeconfig_auth_info(auth_info)
+        def from_auth_info(auth_info)
+          Factory.new.from_auth_info(auth_info)
+        end
       end
     end
   end

--- a/lib/k8y/rest/auth.rb
+++ b/lib/k8y/rest/auth.rb
@@ -1,76 +1,17 @@
 # frozen_string_literal: true
+
+require_relative "auth/factory"
+
 module K8y
   module REST
-    class Auth
+    module Auth
+      extend self
       InvalidAuthTypeError = Class.new(Error)
 
-      class << self
-        def from_kubeconfig(kubeconfig, context: nil)
-          context = context ? context : kubeconfig.current_context
-          auth_info = kubeconfig.user_for_context(context).auth_info
-
-          new(token: token(auth_info), username: auth_info.username, password: auth_info.password,
-            auth_provider: auth_provider(auth_info), exec_provider: exec_provider(auth_info))
-        end
-
-        private
-
-        def token(auth_info)
-          return auth_info.token if auth_info.token
-          File.read(auth_info.token_file) if auth_info.token_file
-        end
-
-        def auth_provider(auth_info)
-          # TODO
-        end
-
-        def exec_provider(auth_info)
-          # TODO
-        end
-      end
-
-      def initialize(token: nil, username: nil, password: nil, auth_provider: nil, exec_provider: nil)
-        @token = token
-        @username = username
-        @password = password
-        @auth_provider = auth_provider
-        @exec_provider = exec_provider
-      end
-
-      def configure_connection(connection)
-        case auth_type
-        when :basic
-          connection.basic_auth(username, password)
-        when :token
-          connection.headers[:Authorization] = "Bearer #{token}"
-          # TODO...
-        end
-      end
-
-      private
-
-      attr_reader :token, :username, :password, :auth_provider, :exec_provider
-
-      def auth_type
-        if username && password
-          :basic
-        elsif token
-          :token
-        elsif auth_provider
-          :auth_provider
-        elsif exec_provider
-          :exec_provider
-        else
-          :none
-        end
-      end
-
-      def basic?
-        auth_type == :basic
-      end
-
-      def token?
-        auth_type == :token
+      def from_kubeconfig(kubeconfig, context: nil)
+        context = context ? context : kubeconfig.current_context
+        auth_info = kubeconfig.user_for_context(context).auth_info
+        Factory.new_from_kubeconfig_auth_info(auth_info)
       end
     end
   end

--- a/lib/k8y/rest/auth/auth_base.rb
+++ b/lib/k8y/rest/auth/auth_base.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module K8y
+  module REST
+    module Auth
+      class AuthBase
+        def configure_connection(connection)
+        end
+      end
+    end
+  end
+end

--- a/lib/k8y/rest/auth/basic.rb
+++ b/lib/k8y/rest/auth/basic.rb
@@ -13,7 +13,7 @@ module K8y
         end
 
         def configure_connection(connection)
-          connection.basic_auth(username, password)
+          connection.request(:authorization, :basic, username, password)
         end
 
         private

--- a/lib/k8y/rest/auth/basic.rb
+++ b/lib/k8y/rest/auth/basic.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require_relative "auth_base"
+
+module K8y
+  module REST
+    module Auth
+      class Basic < AuthBase
+        def initialize(username:, password:)
+          super()
+          @username = username
+          @password = password
+        end
+
+        def configure_connection(connection)
+          connection.basic_auth(username, password)
+        end
+
+        private
+
+        attr_reader :username, :password
+      end
+    end
+  end
+end

--- a/lib/k8y/rest/auth/factory.rb
+++ b/lib/k8y/rest/auth/factory.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require_relative "basic"
+require_relative "token"
+require_relative "providers/factory"
+
+module K8y
+  module REST
+    module Auth
+      class Factory
+        class << self
+          def new_from_kubeconfig_auth_info(auth_info)
+            if auth_info.username && auth_info.password
+              Basic.new(username: auth_info.username, password: auth_info.password)
+            elsif auth_info.token
+              Token.new(token: token)
+            elsif auth_info.auth_provider
+              Providers::Factory.from_provider(auth_info[AUTH_PROVIDER_KEY])
+            else
+              AuthBase.new
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/k8y/rest/auth/factory.rb
+++ b/lib/k8y/rest/auth/factory.rb
@@ -8,17 +8,15 @@ module K8y
   module REST
     module Auth
       class Factory
-        class << self
-          def new_from_kubeconfig_auth_info(auth_info)
-            if auth_info.username && auth_info.password
-              Basic.new(username: auth_info.username, password: auth_info.password)
-            elsif auth_info.token
-              Token.new(token: token)
-            elsif auth_info.auth_provider
-              Providers::Factory.from_provider(auth_info[AUTH_PROVIDER_KEY])
-            else
-              AuthBase.new
-            end
+        def from_auth_info(auth_info)
+          if auth_info.username && auth_info.password
+            Basic.new(username: auth_info.username, password: auth_info.password)
+          elsif auth_info.token
+            Token.new(token: auth_info.token)
+          elsif auth_info.auth_provider
+            Providers::Factory.new.from_auth_provider(auth_info.auth_provider)
+          else
+            AuthBase.new
           end
         end
       end

--- a/lib/k8y/rest/auth/providers/factory.rb
+++ b/lib/k8y/rest/auth/providers/factory.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative "gcp/factory"
+
+module K8y
+  module REST
+    module Auth
+      module Providers
+        class Factory
+          def from_provider(provider)
+            case provider["name"]
+            when "gcp"
+              GCP::Factory.from_provider(provider)
+            when nil
+              raise UnnamedProviderError
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/k8y/rest/auth/providers/factory.rb
+++ b/lib/k8y/rest/auth/providers/factory.rb
@@ -6,11 +6,14 @@ module K8y
   module REST
     module Auth
       module Providers
+        Error = Class.new(Error)
+
         class Factory
-          def from_provider(provider)
-            case provider["name"]
+          UnnamedProviderError = Class.new(Error)
+          def from_auth_provider(provider)
+            case provider[:name]
             when "gcp"
-              GCP::Factory.from_provider(provider)
+              GCP::Factory.new.from_auth_provider(provider)
             when nil
               raise UnnamedProviderError
             end

--- a/lib/k8y/rest/auth/providers/gcp/application_default_provider.rb
+++ b/lib/k8y/rest/auth/providers/gcp/application_default_provider.rb
@@ -15,11 +15,14 @@ module K8y
               "https://www.googleapis.com/auth/userinfo.email",
             ]
 
-            # TODO: model refresh tokens, automated refresh, etc.
+            # #get_application_default actually returns a full oauth2 token payload
+            # This gives us, among other things, a refresh token, that we should be
+            # able to hold on to transparently keep client connections alive and
+            # healthy.
             def token
-              authorization = Google::Auth.get_application_default(SCOPES)
-              authorization.apply({})
-              authorization.access_token
+              creds = Google::Auth.get_application_default(SCOPES)
+              creds.apply({})
+              creds.access_token
             end
           end
         end

--- a/lib/k8y/rest/auth/providers/gcp/application_default_provider.rb
+++ b/lib/k8y/rest/auth/providers/gcp/application_default_provider.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "googleauth"
+
+require_relative "../provider_base"
+
+module K8y
+  module REST
+    module Auth
+      module Providers
+        module GCP
+          class ApplicationDefaultProvider < ProviderBase
+            SCOPES = [
+              "https://www.googleapis.com/auth/cloud-platform",
+              "https://www.googleapis.com/auth/userinfo.email",
+            ]
+
+            # TODO: model refresh tokens, automated refresh, etc.
+            def token
+              authorization = Google::Auth.get_application_default(SCOPES)
+              authorization.apply({})
+              authorization.access_token
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/k8y/rest/auth/providers/gcp/command_provider.rb
+++ b/lib/k8y/rest/auth/providers/gcp/command_provider.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require "googleauth"
+require "json"
+require "open3"
+require "shellwords"
+
+require_relative "../provider_base"
+
+module K8y
+  module REST
+    module Auth
+      module Providers
+        module GCP
+          class CommandProvider < ProviderBase
+            # TODO: this is a shameless copy of abonas/kubeclient. It's worth it to build this from scratch,
+            # if only for the better understanding that comes along with it
+            def initialize(cmd_path:, access_token: nil, cmd_args: nil, expiry: nil, expiry_key: nil, token_key: nil)
+              super
+              @access_token = access_token
+              @cmd_args = cmd_args
+              @cmd_path = cmd_path
+              @expiry = expiry
+              @expiry_key = expiry_key
+              @token_key = token_key
+            end
+
+            def token
+              out, err, st = Open3.capture3(cmd, *args.split)
+
+              raise "exec command failed: #{err}" unless st.success?
+
+              extract_token(out, token_key)
+            end
+
+            private
+
+            def extract_token(output, key)
+              path =
+                key
+                  .gsub(/\A{(.*)}\z/, '\\1') # {.foo.bar} -> .foo.bar
+                  .sub(/\A\./, "") # .foo.bar -> foo.bar
+                  .split(".")
+              JSON.parse(output).dig(*path)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/k8y/rest/auth/providers/gcp/factory.rb
+++ b/lib/k8y/rest/auth/providers/gcp/factory.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require_relative "application_default_provider"
+require_relative "command_provider"
+
 module K8y
   module REST
     module Auth
@@ -11,7 +14,7 @@ module K8y
             MissingConfigError = Class.new(Error)
 
             def from_auth_provider(provider)
-              config = provider["config"]
+              config = provider[:config]
               raise MissingConfigError unless config
 
               # see https://github.com/kubernetes/client-go/blob/master/plugin/pkg/client/auth/gcp/gcp.go#L58

--- a/lib/k8y/rest/auth/providers/gcp/factory.rb
+++ b/lib/k8y/rest/auth/providers/gcp/factory.rb
@@ -5,30 +5,27 @@ module K8y
     module Auth
       module Providers
         module GCP
+          Error = Class.new(Error)
+
           class Factory
-            Error = Class.new(Error)
-            MisisngConfigError = Class.new(Error)
+            MissingConfigError = Class.new(Error)
 
-            class << self
+            def from_auth_provider(provider)
+              config = provider["config"]
+              raise MissingConfigError unless config
+
               # see https://github.com/kubernetes/client-go/blob/master/plugin/pkg/client/auth/gcp/gcp.go#L58
-              RECOGNIZED_KEYS = [:"access-token", :"cmd-args", :"cmd-path", :expiry, :"expiry-key", :"token-key"]
-
-              def from_provider(provider)
-                config = provider["config"]
-                raise MissingConfigError unless config
-
-                if config[:"cmd-path"]
-                  CommandProvider.new(
-                    access_token: config[:"access-token"],
-                    cmd_args: config[:"cmd-args"],
-                    cmd_path: config[:"cmd-path"],
-                    expiry: config[:expiry],
-                    expiry_key: config[:"expiry-key"],
-                    token_key: config[:"token-key"]
-                  )
-                else
-                  ApplicationDefaultProvider.new
-                end
+              if config[:"cmd-path"]
+                CommandProvider.new(
+                  access_token: config[:"access-token"],
+                  cmd_args: config[:"cmd-args"],
+                  cmd_path: config[:"cmd-path"],
+                  expiry: config[:expiry],
+                  expiry_key: config[:"expiry-key"],
+                  token_key: config[:"token-key"]
+                )
+              else
+                ApplicationDefaultProvider.new
               end
             end
           end

--- a/lib/k8y/rest/auth/providers/gcp/factory.rb
+++ b/lib/k8y/rest/auth/providers/gcp/factory.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module K8y
+  module REST
+    module Auth
+      module Providers
+        module GCP
+          class Factory
+            Error = Class.new(Error)
+            MisisngConfigError = Class.new(Error)
+
+            class << self
+              # see https://github.com/kubernetes/client-go/blob/master/plugin/pkg/client/auth/gcp/gcp.go#L58
+              RECOGNIZED_KEYS = [:"access-token", :"cmd-args", :"cmd-path", :expiry, :"expiry-key", :"token-key"]
+
+              def from_provider(provider)
+                config = provider["config"]
+                raise MissingConfigError unless config
+
+                if config[:"cmd-path"]
+                  CommandProvider.new(
+                    access_token: config[:"access-token"],
+                    cmd_args: config[:"cmd-args"],
+                    cmd_path: config[:"cmd-path"],
+                    expiry: config[:expiry],
+                    expiry_key: config[:"expiry-key"],
+                    token_key: config[:"token-key"]
+                  )
+                else
+                  ApplicationDefaultProvider.new
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/k8y/rest/auth/providers/provider_base.rb
+++ b/lib/k8y/rest/auth/providers/provider_base.rb
@@ -2,9 +2,12 @@
 
 module K8y
   module Auth
-    class ProviderBase
-      def token
-        raise NotImplementedError
+    module Providers
+      class ProviderBase
+        # TODO: public API not finalized; subject to change
+        def token
+          raise NotImplementedError
+        end
       end
     end
   end

--- a/lib/k8y/rest/auth/providers/provider_base.rb
+++ b/lib/k8y/rest/auth/providers/provider_base.rb
@@ -1,12 +1,14 @@
 # frozen_string_literal: true
 
 module K8y
-  module Auth
-    module Providers
-      class ProviderBase
-        # TODO: public API not finalized; subject to change
-        def token
-          raise NotImplementedError
+  module REST
+    module Auth
+      module Providers
+        class ProviderBase
+          # TODO: public API not finalized; subject to change
+          def token
+            raise NotImplementedError
+          end
         end
       end
     end

--- a/lib/k8y/rest/auth/providers/provider_base.rb
+++ b/lib/k8y/rest/auth/providers/provider_base.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module K8y
+  module Auth
+    class ProviderBase
+      def token
+        raise NotImplementedError
+      end
+    end
+  end
+end

--- a/lib/k8y/rest/auth/token.rb
+++ b/lib/k8y/rest/auth/token.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require_relative "auth_base"
+
+module K8y
+  module REST
+    module Auth
+      class Token < AuthBase
+        def initialize(token:)
+          super()
+          @token = token
+        end
+
+        def configure_connection(connection)
+          connection.headers[:Authorization] = "Bearer #{token}"
+        end
+
+        private
+
+        attr_reader :token
+      end
+    end
+  end
+end

--- a/test/fixtures/kubeconfig/auth_info/auth_provider_empty.yml
+++ b/test/fixtures/kubeconfig/auth_info/auth_provider_empty.yml
@@ -1,0 +1,2 @@
+---
+auth-provider: {}

--- a/test/fixtures/kubeconfig/auth_info/basic.yml
+++ b/test/fixtures/kubeconfig/auth_info/basic.yml
@@ -1,0 +1,3 @@
+---
+username: bogus-user
+password: bogus-password

--- a/test/fixtures/kubeconfig/auth_info/bearer.yml
+++ b/test/fixtures/kubeconfig/auth_info/bearer.yml
@@ -1,0 +1,2 @@
+---
+token: bogus-token

--- a/test/fixtures/kubeconfig/auth_info/complete.yml
+++ b/test/fixtures/kubeconfig/auth_info/complete.yml
@@ -1,3 +1,4 @@
+---
 client-certificate: "test-client-certificate"
 client-certificate-data: "test-client-certificate-data"
 client-key: "test-client-key"

--- a/test/fixtures/kubeconfig/auth_provider.yml
+++ b/test/fixtures/kubeconfig/auth_provider.yml
@@ -1,0 +1,22 @@
+apiVersion: v1
+clusters:
+- cluster:
+    certificate-authority-data: fake-ca-data
+    insecure-skip-tls-verify: false
+    server: https://1.2.3.4
+  name: test-cluster
+contexts:
+- context:
+    cluster: test-cluster
+    namespace: test-ns
+    user: test-user
+  name: test
+current-context: test
+kind: Config
+preferences: 
+  color: true
+users:
+- name: test-user
+  user:
+    auth-provider:
+      name: gcp

--- a/test/fixtures/kubeconfig/auth_token.yml
+++ b/test/fixtures/kubeconfig/auth_token.yml
@@ -1,0 +1,21 @@
+apiVersion: v1
+clusters:
+- cluster:
+    certificate-authority-data: fake-ca-data
+    insecure-skip-tls-verify: false
+    server: https://1.2.3.4
+  name: test-cluster
+contexts:
+- context:
+    cluster: test-cluster
+    namespace: test-ns
+    user: test-user
+  name: test
+current-context: test
+kind: Config
+preferences: 
+  color: true
+users:
+- name: test-user
+  user:
+    token: bogus-token

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -36,6 +36,11 @@ module K8y
       K8y::Kubeconfig.from_file(fixture_file)
     end
 
+    def auth_info_fixture(name)
+      auth_info_hash = YAML.load_file(kubeconfig_fixture_path(name, sub_dir: "auth_info"))
+      K8y::Kubeconfig::AuthInfo.from_hash(auth_info_hash)
+    end
+
     def kubeconfig_fixture_path(name, sub_dir: "")
       File.expand_path(File.join("fixtures", "kubeconfig", sub_dir, "#{name}.yml"), __dir__)
     end

--- a/test/unit/client/api_builder_test.rb
+++ b/test/unit/client/api_builder_test.rb
@@ -7,7 +7,8 @@ module K8y
     class APIBuilderTest < TestCase
       def test_build!
         REST::Connection.expects(:from_config).returns(
-          REST::Connection.new(host: "https://1.2.3.4/apis/test/v1/", auth: REST::Auth.new, ssl: {}) do |builder|
+          REST::Connection.new(host: "https://1.2.3.4/apis/test/v1/", auth: REST::Auth::AuthBase.new,
+            ssl: {}) do |builder|
             builder.adapter(:test, Faraday::Adapter::Test::Stubs.new) do |stub|
               stub.get("https://1.2.3.4/apis/test/v1/") { |_env| [200, {}, discovery_response_fixture("test_v1")] }
             end

--- a/test/unit/kubeconfig/auth_info_test.rb
+++ b/test/unit/kubeconfig/auth_info_test.rb
@@ -6,8 +6,7 @@ module K8y
   module Kubeconfig
     class AuthInfoTest < TestCase
       def test_from_hash_success
-        auth_info_hash = YAML.load_file(kubeconfig_fixture_path("complete", sub_dir: "auth_info"))
-        auth_info = AuthInfo.from_hash(auth_info_hash)
+        auth_info = auth_info_fixture("complete")
         assert_equal("test-client-certificate", auth_info.client_certificate)
         assert_equal("test-client-certificate-data", auth_info.client_certificate_data)
         assert_equal("test-client-key", auth_info.client_key)

--- a/test/unit/rest/auth/providers/factory_test.rb
+++ b/test/unit/rest/auth/providers/factory_test.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+module K8y
+  module REST
+    module Auth
+      module Providers
+        class FactoryTest < TestCase
+          def test_from_auth_provider_raises_unnamed_provider_error_if_provider_name_not_present
+            provider = {}
+            assert_raises(Factory::UnnamedProviderError) { Factory.new.from_auth_provider(provider) }
+          end
+
+          def test_from_auth_provider_calls_gcp_factory_when_provider_name_is_gcp
+            provider = { name: "gcp" }
+            GCP::Factory.any_instance.expects(:from_auth_provider).with(provider)
+            Factory.new.from_auth_provider(provider)
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/unit/rest/auth/providers/gcp/factory_test.rb
+++ b/test/unit/rest/auth/providers/gcp/factory_test.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+module K8y
+  module REST
+    module Auth
+      module Providers
+        module GCP
+          class FactoryTest < TestCase
+            def test_from_auth_provider_returns_application_default_provider_if_cmd_path_not_present_in_config
+              provider = {
+                config: {},
+              }
+              ApplicationDefaultProvider.expects(:new)
+              Factory.new.from_auth_provider(provider)
+            end
+
+            def test_from_auth_provider_returns_command_provider_if_cmd_path_present_in_config
+              provider = {
+                config: {
+                  "cmd-path": "bogus/path",
+                },
+              }
+              CommandProvider.expects(:new)
+              Factory.new.from_auth_provider(provider)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/unit/rest/auth_test.rb
+++ b/test/unit/rest/auth_test.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module K8y
+  module REST
+    class AuthTest < TestCase
+      def test_from_kubeconfig_creates_basic_auth_when_username_and_password_present
+        kubeconfig = config_fixture("simple")
+        assert_instance_of(Auth::Basic, Auth.from_kubeconfig(kubeconfig))
+      end
+
+      def test_from_auth_info_creates_token_auth_when_username_and_password_present
+        kubeconfig = config_fixture("auth_token")
+        assert_instance_of(Auth::Token, Auth.from_kubeconfig(kubeconfig))
+      end
+
+      def test_from_kubeconfig_calls_auth_provider_factory_if_auth_provider_present
+        Auth::Providers::Factory.any_instance.expects(:from_auth_provider)
+        Auth.from_kubeconfig(config_fixture("auth_provider"))
+      end
+
+      def test_from_auth_info_creates_basic_auth_when_username_and_password_present
+        auth_info = auth_info_fixture("basic")
+        assert_instance_of(Auth::Basic, Auth.from_auth_info(auth_info))
+      end
+
+      def test_from_auth_info_creates_token_auth_when_token_present
+        auth_info = auth_info_fixture("bearer")
+        assert_instance_of(Auth::Token, Auth.from_auth_info(auth_info))
+      end
+
+      def test_from_auth_info_calls_auth_provider_factory_if_auth_provider_present
+        auth_info = auth_info_fixture("auth_provider_empty")
+        Auth::Providers::Factory.any_instance.expects(:from_auth_provider)
+        Auth.from_auth_info(auth_info)
+      end
+    end
+  end
+end

--- a/test/unit/rest/client_test.rb
+++ b/test/unit/rest/client_test.rb
@@ -6,7 +6,7 @@ module K8y
   module REST
     class ClientTest < TestCase
       def test_from_config
-        auth = Auth.new(token: "fake-token")
+        auth = Auth::Token.new(token: "fake-token")
         transport = Transport.new
         config = Config.new(
           host: "host",
@@ -122,8 +122,8 @@ module K8y
 
       private
 
-      def with_client(host: "https://1.2.3.4/", auth: Auth.new, ssl: {})
-        connection = Connection.new(host: host, auth: Auth.new, ssl: {})
+      def with_client(host: "https://1.2.3.4/", auth: Auth::AuthBase.new, ssl: {})
+        connection = Connection.new(host: host, auth: auth, ssl: {})
         yield(Client.new(connection: connection))
       end
 


### PR DESCRIPTION
Closes #7 

## Goal

This PR build out the ability to discern what type of authentication strategy should be used and how to configure the underlying `Faraday::Connection` object of a `REST::Client`. Currently, it is able to understand the difference between simple bearer token and basic-auth approaches. In addition, a pattern for dealing with `auth-provider` blocks has also been built out, using GCP as a learning example.

## Design 

It's basically factories all the way down. At the top level, a factory reads from `Kubeconfig::AuthInfo` and decides between basic auth, bearer token, or auth-provider. The former 2 are handled easily enough, but the second one requires an additional factory, as we may need auth-providers for any number of custom providers. A later mechanism to allow for custom loading of auth-provider classes is an idea that's in my mind, but is not being implemented here. Finally, since GCP auth can be either via Application Default Credentials or `cmd-path`, an additional factory specific for GCP auth providers is also present.

With regards to remaining work, the question of how to deal with refresh tokens (generically and in specific instances) still eludes me. I need access to an actual GCP k8s cluster to mess around with the refresh flow. For the purposes of this PR, I think it will be sufficient to at least be able to provision a token via both ADC and `cmd-path`: the remaining work can be pushed further down the road.

## TODO

DO NOT MERGE UNTIL THESE ARE DONE

- [x] Unit tests
- [x] 🎩 ADC + `cmd-path` GCP credentials