### PR TITLE
Custom faraday settings

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,5 +4,8 @@ inherit_gem:
 Naming/AccessorMethodName:
   Enabled: false
 
+Style/ExplicitBlockArgument:
+  Enabled: false
+
 AllCops:
   SuggestExtensions: false

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ For maintainers, the goal is to provide a highly testable, modular, and loosely 
 [**Basic usage**](#basic-usage)
 * [From a Config file](#from-a-config-file)
 * [From in-cluster](#from-in-cluster)
+* [Token renewal](#token-renewal)
 * [Client options](#client-options)
   * [Kubeconfig](#kubeconfig)
   * [Faraday connection settings](#faraday-connection-settings)
@@ -42,6 +43,10 @@ client = K8y::Client.from_in_cluster
 client.discover!
 client.get_pods(namespace: "some-namespace")
 ```
+
+## Token renewal
+
+If your client connection's authorization is achieved via a generated token (e.g. via an `auth-provider` stanza in your kubeconfig), K8y will automatically attempt to regenerate a new token if it receives a `401 Unauthorized` error. Currently, only GCP [Application Default Credentials](https://github.com/tsontario/k8y/blob/main/lib/k8y/rest/auth/providers/gcp/application_default_provider.rb) and [Command Provider](https://github.com/tsontario/k8y/blob/main/lib/k8y/rest/auth/providers/gcp/command_provider.rb) have been implemented, but more can/will be added as needed.
 
 ## Client options
 
@@ -94,7 +99,7 @@ K8y::REST::FaradaySettings.with_connection do |connection|
 end
 ```
 
->Warn: Be aware that `FaradaySettings` are **global** and will be applied to all clients (both `K8y::Client::Client` and `K8y::REST::Client`). You can always call `FaradaySettings#with_connection` again to change the block that will be called when generating future clients.
+Be aware that `FaradaySettings` are **global** and will be applied to all clients (both `K8y::Client::Client` and `K8y::REST::Client`). You can always call `FaradaySettings#with_connection` again to change the block that will be called when generating future clients.
 
 # Lower-level usage
 

--- a/README.md
+++ b/README.md
@@ -8,17 +8,17 @@ For maintainers, the goal is to provide a highly testable, modular, and loosely 
 
 ## Table of contents
 
-**Basic usage**
+[**Basic usage**](#basic-usage)
 * [From a Config file](#from-a-config-file)
 * [From in-cluster](#from-in-cluster)
 * [Client options](#client-options)
   * [Kubeconfig](#kubeconfig)
   * [Faraday connection settings](#faraday-connection-settings)
 
-**Lower level usage**
+[**Lower level usage**](#lower-level-usage)
 * [REST client](#rest-client)
 
-**Testing & contributing**
+[**Testing and contributing**](#testing-and-contributing)
 * [Test suite](#test-suite)
 * [Contributing](#contributing)
 
@@ -111,7 +111,7 @@ rest_client = K8y::REST::Client.from_config(rest_config)
 rest_client.get("healthz", as: :raw)
 ```
 
-# Testing & contributing
+# Testing and contributing
 
 ## Test suite*
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,23 @@ For users, this gem is intended to be simple to use, but with enough flexibility
 
 For maintainers, the goal is to provide a highly testable, modular, and loosely coupled design to allow for easy change management and confidence in production worthiness.
 
+## Table of contents
+
+**Basic usage**
+* From a Config file[#from-a-config-file]
+* From in-cluster[#from-in-cluster]
+* Client options[#client-options]
+  * Kubeconfig[#kubeconfig]
+  * Faraday connection settings[#faraday-connection-settings]
+
+**Lower level usage**
+* REST client[#rest-client
+
+**Testing & contributing**
+* Test suite[#test-suite]
+* Contributing[#contributing]
+
+
 # Basic usage
 
 ## From a Config file
@@ -27,6 +44,8 @@ client.get_pods(namespace: "some-namespace")
 ```
 
 ## Client options
+
+### Kubeconfig
 
 By default, `Kubeconfig.from_file` will read the file pointed to by `ENV["KUBECONFIG"]`, but a separate filepath can be provided.
 
@@ -62,7 +81,24 @@ client.get_ingress(namespace: "some-namespace", name: "my-ingress")
 
 If a conflict arises between group versions, a `K8y::Client::APINameConflictError` will be raised when trying to access a duplicate-named resource. **A future feature will allow fine-grained access to client group versions. E.g. `client.api_extensions_v1.get_ingresses**
 
-# Lower-level access
+### Faraday Connection settings
+
+A `K8y::Client::Client` object will maintain a separate `K8y::REST::Connection` for each `GroupVersion` it accesses. Each `K8y::REST::Connection`, in turn, has its own `Faraday::Connection`. `K8y::REST::FaradaySettings` is exposed in order to provide a mechanism to globally configure Faraday settings across all client instances. Use `K8y::REST::FaradaySettings#with_connection` to pass in a block that will be evaluated when new REST clients are built.
+
+```ruby
+# Setting global Faraday::Connection settings
+K8y::REST::FaradaySettings.with_connection do |connection|
+  connection.headers["Foo"] = "Bar"
+  connection.options.timeout = 5 # 5 seconds
+  connection.response :follow_redirects
+end
+```
+
+>Warn: Be aware that `FaradaySettings` are **global** and will be applied to all clients (both `K8y::Client::Client` and `K8y::REST::Client`). You can always call `FaradaySettings#with_connection` again to change the block that will be called when generating future clients.
+
+# Lower-level usage
+
+## REST client
 
 Under the hood, `K8y::Client` makes its requests via a more generic REST client: `K8y::REST::Client`. REST clients can be instantiated much the same as top-level Clients. The `path:` argument will be used as a prefix for all requests made by the client. E.g. given a cluster server of `https://1.2.3.4`, and path `foo`, `rest_client.get("bar")` will make a request to `https://1.2.3.4/foo/bar`
 
@@ -75,7 +111,9 @@ rest_client = K8y::REST::Client.from_config(rest_config)
 rest_client.get("healthz", as: :raw)
 ```
 
-# Testing
+# Testing & contributing
+
+## Test suite*
 
 Basic test suite: `bundle exec rake`
 
@@ -83,6 +121,6 @@ Integration test suite: `bundle exec rake test_integration` (requires a running 
 
 A future goal is to test in-cluster behaviour by running a custom Github action, but that hasn't been done yet.
 
-# Contributing
+## Contributing
 
 Contributions are always welcome!

--- a/README.md
+++ b/README.md
@@ -9,18 +9,18 @@ For maintainers, the goal is to provide a highly testable, modular, and loosely 
 ## Table of contents
 
 **Basic usage**
-* From a Config file[#from-a-config-file]
-* From in-cluster[#from-in-cluster]
-* Client options[#client-options]
-  * Kubeconfig[#kubeconfig]
-  * Faraday connection settings[#faraday-connection-settings]
+* [From a Config file](#from-a-config-file)
+* [From in-cluster](#from-in-cluster)
+* [Client options](#client-options)
+  * [Kubeconfig](#kubeconfig)
+  * [Faraday connection settings](#faraday-connection-settings)
 
 **Lower level usage**
-* REST client[#rest-client
+* [REST client](#rest-client)
 
 **Testing & contributing**
-* Test suite[#test-suite]
-* Contributing[#contributing]
+* [Test suite](#test-suite)
+* [Contributing](#contributing)
 
 
 # Basic usage

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ rest_client.get("healthz", as: :raw)
 
 # Testing and contributing
 
-## Test suite*
+## Test suite
 
 Basic test suite: `bundle exec rake`
 

--- a/k8y.gemspec
+++ b/k8y.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency("activesupport", "~> 6.0")
   spec.add_dependency("faraday", "~> 1.8")
+  spec.add_dependency("faraday_middleware", "~> 1")
   spec.add_dependency("googleauth")
   spec.add_dependency("railties", "~> 6.0")
   spec.add_dependency("recursive-open-struct", "~>1.1")

--- a/lib/k8y/rest/client.rb
+++ b/lib/k8y/rest/client.rb
@@ -6,6 +6,7 @@ require "forwardable"
 
 require_relative "config"
 require_relative "connection"
+require_relative "faraday_settings"
 require_relative "request_wrapper"
 require_relative "response_formatter"
 

--- a/lib/k8y/rest/connection.rb
+++ b/lib/k8y/rest/connection.rb
@@ -27,6 +27,7 @@ module K8y
         @auth = auth
         @connection = Faraday.new(base_path, ssl: ssl) do |connection|
           connection.use(Faraday::Response::RaiseError)
+          FaradaySettings.configure_connection(connection)
           auth.configure_connection(connection)
           yield connection if block_given?
         end

--- a/lib/k8y/rest/faraday_settings.rb
+++ b/lib/k8y/rest/faraday_settings.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module K8y
+  module REST
+    class FaradaySettings
+      class << self
+        attr_reader :config_lambda
+
+        def configure_connection(connection)
+          config_lambda&.call(connection)
+        end
+
+        def with_connection(&block)
+          @config_lambda = ->(connection) { yield(connection) }
+        end
+      end
+    end
+  end
+end

--- a/lib/k8y/version.rb
+++ b/lib/k8y/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module K8y
-  VERSION = "0.3.0"
+  VERSION = "0.4.0"
 end

--- a/test/unit/rest/connection_test.rb
+++ b/test/unit/rest/connection_test.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module K8y
+  module REST
+    class ConnectionTest < TestCase
+      # Not parallelizable due to FaradaySettings being a singleton
+      def test_faraday_settings_are_configured_in_client_connection
+        FaradaySettings.with_connection do |connection|
+          connection.headers["FaradaySettings"] = "bogus"
+        end
+        connection = Connection.new(base_path: "https://bogus.com", auth: Auth::AuthBase.new, ssl: {})
+        assert_equal("bogus", connection.connection.headers["FaradaySettings"])
+      ensure
+        FaradaySettings.with_connection { |_| }
+      end
+    end
+  end
+end


### PR DESCRIPTION
Allow custom Faraday connection settings to be provided by users.

As far as implementation goes, settings are provided via the singleton `K8y::REST::FaradaySettings`. Users can provide a block via `FaradaySettings#with_connection` which returns a lambda that will be called when instantiating the Faraday connection (in `K8y::REST::Connection.new`).

Of course the tradeoff here is that the singleton class indiscriminately affects _all_ clients created. An easy workaround if one requires more fine-tuning is just to recall `#with_connection` if you need to instantiate new clients with different needs (though this seems like a strange use-case)