### PR TITLE
Small fixes via Rubycritic suggestions

### DIFF
--- a/lib/k8y/rest/client.rb
+++ b/lib/k8y/rest/client.rb
@@ -35,7 +35,7 @@ module K8y
         @request_wrapper = RequestWrapper.new
       end
 
-      def get(path = "", headers: {}, as: :ros)
+      def get(path = "", as: :ros)
         with_wrapper do
           response = connection.get(formatted_uri(path))
           format_response(response, as: as)
@@ -63,7 +63,7 @@ module K8y
         end
       end
 
-      def delete(path = "", headers: {}, as: :ros)
+      def delete(path = "", as: :ros)
         with_wrapper do
           response = connection.delete(formatted_uri(path))
           format_response(response, as: as)

--- a/lib/k8y/rest/connection.rb
+++ b/lib/k8y/rest/connection.rb
@@ -10,7 +10,6 @@ module K8y
       extend Forwardable
 
       attr_reader :base_path, :connection
-      attr_accessor :token_store
 
       VERBS = [:get, :post, :put, :patch, :delete]
       def_delegators(:connection, *VERBS)


### PR DESCRIPTION
Ran [rubycritic](https://github.com/whitesmith/rubycritic) and identified a few egregious cases that I've fixed for now. For headers in `REST::Client`, we probably _do_ want to support fine-grained setting of headers, but that will require a dedicated PR so I've opted to remove it for now since the parameter is a lie and doesn't actually add the header to the call.