### PR TITLE
Label selector filter

### DIFF
--- a/lib/k8y/client/api_builder.rb
+++ b/lib/k8y/client/api_builder.rb
@@ -19,6 +19,10 @@ module K8y
         update: :define_update_resource,
       }
 
+      GET_RESOURCES_OPTIONS = {
+        label_selector: "labelSelector",
+      }
+
       def initialize(api:, config:, context:)
         super()
         @api = api
@@ -52,11 +56,11 @@ module K8y
         api.instance_eval do
           define_singleton_method(method_name) do |kwargs = {}|
             namespace = kwargs.fetch(:namespace) if resource_description.namespaced
-            data = kwargs.fetch(:data)
+            body = kwargs.fetch(:body)
             headers = kwargs.fetch(:headers, {}).merge(json_content_type)
             as = kwargs.fetch(:as, :ros)
             rest_client.post(resource_description.path_for_resources(namespace: namespace),
-              data: JSON.dump(data), headers: headers, as: as)
+              body: JSON.dump(body), headers: headers, as: as)
           end
           register_method(method_name)
         end
@@ -68,10 +72,8 @@ module K8y
           define_singleton_method(method_name) do |kwargs = {}|
             namespace = kwargs.fetch(:namespace) if resource_description.namespaced
             name = kwargs.fetch(:name)
-            headers = kwargs.fetch(:headers, {})
             as = kwargs.fetch(:as, :ros)
-            rest_client.delete(resource_description.path_for_resource(namespace: namespace, name: name),
-              headers: headers, as: as)
+            rest_client.delete(resource_description.path_for_resource(namespace: namespace, name: name), as: as)
           end
           register_method(method_name)
         end
@@ -98,8 +100,13 @@ module K8y
           define_singleton_method(method_name) do |kwargs = {}|
             namespace = kwargs.fetch(:namespace) if resource_description.namespaced
             headers = kwargs.fetch(:headers, {})
+            params = {}
+            ::K8y::Client::APIBuilder::GET_RESOURCES_OPTIONS.each do |opt, key|
+              params[key] = kwargs[opt] if kwargs[opt]
+            end
             as = kwargs.fetch(:as, :ros)
-            rest_client.get(resource_description.path_for_resources(namespace: namespace), headers: headers, as: as)
+            rest_client.get(resource_description.path_for_resources(namespace: namespace), params: params,
+              headers: headers, as: as)
           end
           register_method(method_name)
         end
@@ -118,12 +125,12 @@ module K8y
           define_singleton_method(method_name) do |kwargs = {}|
             namespace = kwargs.fetch(:namespace) if resource_description.namespaced
             name = kwargs.fetch(:name)
-            data = kwargs.fetch(:data)
+            body = kwargs.fetch(:body)
             strategy = kwargs.fetch(:strategy)
             headers = kwargs.fetch(:headers, {}).merge(scoped_content_type_for_patch_strategy.call(strategy))
             as = kwargs.fetch(:as, :ros)
             rest_client.patch(resource_description.path_for_resource(namespace: namespace, name: name),
-              strategy: strategy, data: JSON.dump(data), headers: headers, as: as)
+              strategy: strategy, body: JSON.dump(body), headers: headers, as: as)
           end
           register_method(method_name)
         end
@@ -142,11 +149,11 @@ module K8y
           api.define_singleton_method(method_name) do |kwargs = {}|
             namespace = kwargs.fetch(:namespace) if resource_description.namespaced
             name = kwargs.fetch(:name)
-            data = kwargs.fetch(:data)
+            body = kwargs.fetch(:body)
             headers = kwargs.fetch(:headers, {}).merge(json_content_type)
             as = kwargs.fetch(:as, :ros)
             rest_client.put(resource_description.path_for_resource(namespace: namespace, name: name),
-              data: JSON.dump(data), headers: headers, as: as)
+              body: JSON.dump(body), headers: headers, as: as)
           end
           register_method(method_name)
         end

--- a/lib/k8y/rest/client.rb
+++ b/lib/k8y/rest/client.rb
@@ -35,37 +35,37 @@ module K8y
         @request_wrapper = RequestWrapper.new
       end
 
-      def get(path = "", as: :ros)
+      def get(path = "", params: {}, headers: {}, as: :ros)
         with_wrapper do
-          response = connection.get(formatted_uri(path))
+          response = connection.get(formatted_uri(path), params, headers)
           format_response(response, as: as)
         end
       end
 
-      def post(path = "", data:, headers: {}, as: :ros)
+      def post(path = "", body:, headers: {}, as: :ros)
         with_wrapper do
-          response = connection.post(formatted_uri(path), data, headers)
+          response = connection.post(formatted_uri(path), body, headers)
           format_response(response, as: as)
         end
       end
 
-      def put(path = "", data:, headers: {}, as: :ros)
+      def put(path = "", body:, headers: {}, as: :ros)
         with_wrapper do
-          response = connection.put(formatted_uri(path), data, headers)
+          response = connection.put(formatted_uri(path), body, headers)
           format_response(response, as: as)
         end
       end
 
-      def patch(path = "", strategy:, data:, headers: {}, as: :ros)
+      def patch(path = "", strategy:, body:, headers: {}, as: :ros)
         with_wrapper do
-          response = connection.patch(formatted_uri(path), data, headers)
+          response = connection.patch(formatted_uri(path), body, headers)
           format_response(response, as: as)
         end
       end
 
-      def delete(path = "", as: :ros)
+      def delete(path = "", params: {}, headers: {}, as: :ros)
         with_wrapper do
-          response = connection.delete(formatted_uri(path))
+          response = connection.delete(formatted_uri(path), params, headers)
           format_response(response, as: as)
         end
       end

--- a/lib/k8y/rest/client.rb
+++ b/lib/k8y/rest/client.rb
@@ -35,7 +35,7 @@ module K8y
         @request_wrapper = RequestWrapper.new
       end
 
-      def get(path = "", headers: {}, as: :ros)
+      def get(path = "", as: :ros)
         with_wrapper do
           response = connection.get(formatted_uri(path))
           format_response(response, as: as)
@@ -63,7 +63,7 @@ module K8y
         end
       end
 
-      def delete(path = "", headers: {}, as: :ros)
+      def delete(path = "", as: :ros)
         with_wrapper do
           response = connection.delete(formatted_uri(path))
           format_response(response, as: as)

--- a/lib/k8y/rest/connection.rb
+++ b/lib/k8y/rest/connection.rb
@@ -10,7 +10,6 @@ module K8y
       extend Forwardable
 
       attr_reader :base_path, :connection
-      attr_accessor :token_store
 
       VERBS = [:get, :post, :put, :patch, :delete]
       def_delegators(:connection, *VERBS)

--- a/test/cluster_integration/client/api_test.rb
+++ b/test/cluster_integration/client/api_test.rb
@@ -32,7 +32,7 @@ module K8y
 
       def test_create_configmap
         configmap = YAML.load_file(resource_fixture_path("configmap"))
-        create_result = client.create_configmap(name: "test-configmap", namespace: @namespace, data: configmap)
+        create_result = client.create_configmap(name: "test-configmap", namespace: @namespace, body: configmap)
         get_result = client.get_configmap(name: "test-configmap", namespace: @namespace)
         assert_equal(get_result, create_result)
       end
@@ -49,7 +49,7 @@ module K8y
         configmap = client.get_configmap(name: "test-configmap", namespace: @namespace)
         refute(configmap.metadata.annotations)
         configmap.metadata.annotations = { test: "bogus" }
-        result = client.update_configmap(name: "test-configmap", namespace: @namespace, data: configmap.to_h)
+        result = client.update_configmap(name: "test-configmap", namespace: @namespace, body: configmap.to_h)
         assert_equal("bogus", result.metadata.annotations.test)
       end
 
@@ -59,7 +59,7 @@ module K8y
         refute(configmap.data.json_patch)
         patch_data = [{ "op" => "add", "path" => "/data/json_patch", "value" => "test" }]
         result = client.patch_configmap(strategy: :json, name: "test-configmap",
-          namespace: @namespace, data: patch_data)
+          namespace: @namespace, body: patch_data)
         assert_equal("test", result.data.json_patch)
       end
 
@@ -69,7 +69,7 @@ module K8y
         refute(configmap.data.merge_patch)
         patch_data = { data: { merge_patch: "test" } }
         result = client.patch_configmap(strategy: :merge, name: "test-configmap",
-          namespace: @namespace, data: patch_data)
+          namespace: @namespace, body: patch_data)
         assert_equal("test", result.data.merge_patch)
       end
 
@@ -93,7 +93,7 @@ module K8y
           },
         }
         result = client.patch_deployment(name: "busybox", namespace: @namespace,
-          data: patch_data, strategy: :strategic_merge)
+          body: patch_data, strategy: :strategic_merge)
         assert_equal(2, result.spec.template.spec.containers.length)
         assert(result.spec.template.spec.containers.map(&:name).include?("addition"))
       end
@@ -119,7 +119,7 @@ module K8y
           },
         }
         result = client.patch_deployment(name: "busybox", namespace: @namespace,
-          data: patch_data, strategy: :strategic_merge)
+          body: patch_data, strategy: :strategic_merge)
         assert_equal(1, result.spec.template.spec.containers.length)
         assert_equal("replacement", result.spec.template.spec.containers.first.name)
       end
@@ -146,13 +146,13 @@ module K8y
           },
         }
         result = client.patch_deployment(name: "busybox", namespace: @namespace,
-          data: patch_data, strategy: :strategic_merge)
+          body: patch_data, strategy: :strategic_merge)
         refute(result.spec.template.spec.containers.first.ports)
       end
 
       def test_client_raises_argument_error_when_unsupported_patch_strategy_specified
         assert_raises(ArgumentError) do
-          client.patch_configmap(name: "foo", namespace: @namespace, data: { data: { fake: "data" } }, strategy: :fake)
+          client.patch_configmap(name: "foo", namespace: @namespace, body: { data: { fake: "data" } }, strategy: :fake)
         end
       end
     end

--- a/test/cluster_integration/client/get_resources_options_test.rb
+++ b/test/cluster_integration/client/get_resources_options_test.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "cluster_integration_test_helper"
+
+module K8y
+  module Client
+    class APITest < IntegrationTestCase
+      def setup
+        client.discover!
+      end
+
+      def test_label_selector_selects_pods_with_matching_label
+        create_from_fixture("deployment")
+        create_from_fixture("deployment_extra_labels")
+
+        deployments = client.get_deployments(namespace: @namespace)
+        assert_equal(2, deployments.length)
+
+        label_selected = client.get_deployments(namespace: @namespace, label_selector: "extra=labels")
+        assert_equal(1, label_selected.length)
+        assert_equal("busybox-extra-labels", label_selected.first.metadata.name)
+      end
+    end
+  end
+end

--- a/test/fixtures/integration/resources/deployment_extra_labels.yml
+++ b/test/fixtures/integration/resources/deployment_extra_labels.yml
@@ -2,10 +2,11 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: busybox
+  name: busybox-extra-labels
   labels:
     name: busybox
     app: busybox
+    extra: labels
 spec:
   replicas: 1
   selector:


### PR DESCRIPTION
This PR enhances the `get_resources` methods to allow passing in of a label selector. While working on this feature, I also tidied up the parameter mapping from `K8y::REST` domain to the underlying `Faraday::Connection` methods. Now, `#put, #post, #patch` methods take a `body` parameter (previously `data:`). Other HTTP methods now all take a `params` parameter, as well.

I'm hoping to deal with the other filters/continuation features for `get_resources` methods in the near future